### PR TITLE
Correctly close the conversion sink in _EterlConversionSink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.4
+- Close conversion sink when the underlying stream closes.
+
 # 1.0.3
 - Decode JS `BigInt`s as `BigInt`s instead of string.
 - Fix some consistency issues.

--- a/benchmark/eterl_benchmark.dart
+++ b/benchmark/eterl_benchmark.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:benchmark_harness/benchmark_harness.dart';
 import 'package:eterl/eterl.dart';
 

--- a/lib/src/eterl.dart
+++ b/lib/src/eterl.dart
@@ -69,7 +69,9 @@ class _EterlConversionSink<T> extends ByteConversionSink {
   }
 
   @override
-  void close() {}
+  void close() {
+    _sink.close();
+  }
 
   @override
   void addSlice(List<int> chunk, int startIndex, int endIndex, bool isLast) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: eterl
 description: Eterl is a fast packer and unpacker for the External Term Erlang Format (version 131).
-version: 1.0.3
+version: 1.0.4
 repository: https://github.com/Rapougnac/eterl
 issue_tracker: https://github.com/Rapougnac/eterl/issues
 

--- a/test/eterl_test.dart
+++ b/test/eterl_test.dart
@@ -690,6 +690,14 @@ void main() {
     test('Wrong version', () {
       expect(() => eterl.unpack([130]), throwsException);
     });
+
+    group('as StreamTransformer', () {
+      test('correctly closes', () {
+        final stream = Stream<List<int>>.empty();
+
+        expect(stream.transform(eterl.unpacker()), emitsDone);
+      });
+    });
   });
 
   group('Encoder', () {


### PR DESCRIPTION
Previously, the sink was not closed when the _EterlConversionSink was closed, meaning the transformed stream never closed. This PR fixes that, and adds 1.0.4 as a new version with this bugfix.